### PR TITLE
added link to uptimerobot rss link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
           <span class="navbar-toggler-icon"></span>
         </button>
         <%= link_to 'ChessApp', root_path, class: 'navbar-brand' %>
+        <%= link_to 'RSS', 'http://rss.uptimerobot.com/u453056-310386fab8b9f430319f7a3c09f51f4a', class: 'nav-link' %>
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav mr-auto">
@@ -52,7 +53,7 @@
     <% end %>
 
     <%= yield %>
-    
+
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </body>
 </html>


### PR DESCRIPTION
- in continuation I added a RSS link to the navigation bar
- uptime robot will ping our heroku url every 5 minutes so that dyno will not sleep and load forever
- here is the screenshots when rss is clicked.
<img width="1186" alt="screen shot 2017-05-28 at 1 57 12 am" src="https://cloud.githubusercontent.com/assets/20747057/26527448/49fc0544-4349-11e7-869b-6a0eac590daa.png">
<img width="1084" alt="screen shot 2017-05-28 at 1 54 34 am" src="https://cloud.githubusercontent.com/assets/20747057/26527449/4b84ea5c-4349-11e7-838c-c221685be396.png">

- image from my uptime robot account instead created an rss feed to check if it is down or not

<img width="694" alt="screen shot 2017-05-28 at 1 54 59 am" src="https://cloud.githubusercontent.com/assets/20747057/26527461/5ebeb242-4349-11e7-8462-6486af9b2f49.png">
