### PR TITLE
Remove piece names from _valid_move? methods

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -9,7 +9,7 @@ class Bishop < Piece
     end
   end
 
-  def bishop_valid_move?(to_x, to_y)
+  def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
     bishop_move_diagonal?(to_x, to_y)
   end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -9,7 +9,7 @@ after_create :icon
     end
   end
 
-  def king_valid_move?(to_x, to_y)
+  def valid_move?(to_x, to_y)
     king_move_horizontal?(to_x) || king_move_vertical?(to_y) || king_move_diagonal?(to_x, to_y)
   end
 

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -9,7 +9,7 @@ after_create :icon
     end
   end
 
-  def knight_valid_move?(to_x, to_y)
+  def valid_move?(to_x, to_y)
     knight_move_wide?(to_x, to_y) || knight_move_tall?(to_x, to_y)
   end
 

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -9,7 +9,7 @@ after_create :icon
     end
   end
 
-  def queen_valid_move?(to_x, to_y)
+  def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
 
     if queen_move_horizontal?(to_x) && queen_move_vertical?(to_y)

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -9,7 +9,7 @@ after_create :icon
     end
   end
 
-  def rook_valid_move?(to_x, to_y)
+  def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
     horizontal_move?(to_x, to_y) || vertical_move?(to_y, to_x)
   end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Bishop, type: :model do
   let(:game) { FactoryGirl.create(:game, white_player_id: user.id)}
   before(:each) { game.pieces.destroy_all }
 
-  describe "#bishop_valid_move?" do
-    subject(:bishop_valid_move?) { bishop.bishop_valid_move?(destination_x, destination_y) }
+  describe "bishop#valid_move?" do
+    subject(:bishop_valid_move?) { bishop.valid_move?(destination_x, destination_y) }
 
     let(:bishop) { FactoryGirl.create(:bishop, color: "White", x_pos: 3, y_pos: 0, game_id: game.id) }
 

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe King, type: :model do
   let(:game) { FactoryGirl.create(:game, black_player_id: user.id)}
   before(:each) { game.pieces.destroy_all }
 
-  describe "#king_valid_move?" do
-    subject(:king_valid_move?) { king.king_valid_move?(destination_x, destination_y) }
+  describe "king#valid_move?" do
+    subject(:king_valid_move?) { king.valid_move?(destination_x, destination_y) }
 
     let(:king) { FactoryGirl.create(:king, color: "Black", x_pos: 4, y_pos: 0, game_id: game.id) }
 

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Knight, type: :model do
   let(:game) { FactoryGirl.create(:game, black_player_id: user.id)}
   before(:each) { game.pieces.destroy_all }
 
-  describe "#knight_valid_move?" do
-    subject(:knight_valid_move?) { knight.knight_valid_move?(to_x, to_y) }
+  describe "knight#valid_move?" do
+    subject(:knight_valid_move?) { knight.valid_move?(to_x, to_y) }
     
     let(:knight) {FactoryGirl.create(:knight, x_pos: 2, y_pos: 0, color: 'White', game_id: game.id)}
     

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Queen, type: :model do
   let(:game) { FactoryGirl.create(:game, white_player_id: user.id)}
   before(:each) { game.pieces.destroy_all }
 
-  describe "#queen_valid_move?" do
-    subject(:queen_valid_move?) { queen.queen_valid_move?(destination_x, destination_y) }
+  describe "queen#valid_move?" do
+    subject(:queen_valid_move?) { queen.valid_move?(destination_x, destination_y) }
 
     let!(:queen) { FactoryGirl.create(:queen, color: "White", x_pos: 3, y_pos: 0, game_id: game.id) }
 

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Rook, type: :model do
     let!(:game) { FactoryGirl.create :game, white_player_id: user.id }
     before(:each) {game.pieces.destroy_all}
 
-    describe "#rook_valid_move?" do
-      subject(:rook_valid_move?) { rook.rook_valid_move?(to_x, to_y) }
+    describe "rook#valid_move?" do
+      subject(:rook_valid_move?) { rook.valid_move?(to_x, to_y) }
       let(:rook) { FactoryGirl.create(:rook, x_pos: 0, y_pos: 0, color: 'White', game_id: game.id) }
 
         context "for valid move" do


### PR DESCRIPTION
- In each of the individual piece STI models, I removed the piece name from the `_valid_move?` method.  Now, each piece model has a method called just `valid_move?`.  

- This allows us to call `piece.valid_move?` from the controller.  For example, if the `piece` is a bishop, it will call `valid_move?` from models/bishop.rb.  Much easier than dealing with 6 differently-named `xxxx_valid_move?` methods.

- The updated tests confirm: due to STI, each separate `valid_move?` method is isolated from the others.  Calling `.valid_move?` on a piece will only call that specific piece's `valid_move?` method and no others.