### PR TITLE
Connect piece valid move

### DIFF
--- a/app/assets/javascripts/games.js
+++ b/app/assets/javascripts/games.js
@@ -14,6 +14,8 @@ $(function() {
           type: 'PUT',
           success: function(data) {
             location.reload();
+            // $(data.id).
+            // console.log(data);
           }
         });
     } else {

--- a/app/assets/javascripts/games.js
+++ b/app/assets/javascripts/games.js
@@ -14,8 +14,6 @@ $(function() {
           type: 'PUT',
           success: function(data) {
             location.reload();
-            // $(data.id).
-            // console.log(data);
           }
         });
     } else {

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,16 +6,19 @@ class PiecesController < ApplicationController
 
 	def update
 		piece = Piece.find(params[:id])
-		logger.info "Params:"
-		logger.info "#{params}"
+		logger.info "Params:
+		Orig x_pos: #{piece.x_pos}, Orig y_pos: #{piece.y_pos},
+		Dest x_pos: #{params[:x_pos]}, Dest y_pos: #{params[:y_pos]}"
+		
 
 		@game = piece.game
 		
 		
 		return render_not_found if piece.blank?
 
-		piece.update_attributes(piece_params)
-		
+		# piece.update_attributes(piece_params)
+		piece.move_to!(params[:x_pos], params[:y_pos])
+
 		if piece.valid?
 			return render json: piece
 		else

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,20 +6,25 @@ class PiecesController < ApplicationController
 
 	def update
 		piece = Piece.find(params[:id])
+		new_x_pos = params[:x_pos].to_i
+		new_y_pos = params[:y_pos].to_i
+
 		logger.info "Params:
-		Orig x_pos: #{piece.x_pos}, Orig y_pos: #{piece.y_pos},
-		Dest x_pos: #{params[:x_pos]}, Dest y_pos: #{params[:y_pos]}"
+		Orig x_pos: #{piece.x_pos.inspect}, Orig y_pos: #{piece.y_pos.inspect},
+		Dest x_pos: #{new_x_pos.inspect}, Dest y_pos: #{params[:y_pos].to_i.inspect}"
 
 		@game = piece.game
 		
 		
 		return render_not_found if piece.blank?
 
-		logger.info "is_obstructed? result: #{piece.is_obstructed?(params[:x_pos], params[:y_pos])}"
-		if piece.is_obstructed?(params[:x_pos], params[:y_pos]) == false
-    	piece.move_to!(params[:x_pos], params[:y_pos])
+		logger.info "is_obstructed? result: #{piece.is_obstructed?(new_x_pos, new_y_pos)}"
+		logger.info "valid_move? results: #{piece.valid_move?(new_x_pos, new_y_pos)}"
+		
+		if piece.valid_move?(new_x_pos, new_y_pos)
+    	piece.move_to!(new_x_pos, new_y_pos)
 		else
-			flash[:alert] = "Your move was obstructed!"
+			flash[:alert] = "Sorry your #{piece.name} can't move there."
 			redirect_to game_path(piece.game)
 		end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -9,21 +9,20 @@ class PiecesController < ApplicationController
 		logger.info "Params:
 		Orig x_pos: #{piece.x_pos}, Orig y_pos: #{piece.y_pos},
 		Dest x_pos: #{params[:x_pos]}, Dest y_pos: #{params[:y_pos]}"
-		logger.info "is_obstructed? result: #{piece.is_obstructed?(params[:x_pos], params[:y_pos]).to_s}"
 
 		@game = piece.game
 		
 		
 		return render_not_found if piece.blank?
 
-		# piece.update_attributes(piece_params)
-		piece.move_to!(params[:x_pos], params[:y_pos])
-
-		if piece.valid?
-			return render json: piece
+		logger.info "is_obstructed? result: #{piece.is_obstructed?(params[:x_pos], params[:y_pos])}"
+		if piece.is_obstructed?(params[:x_pos], params[:y_pos]) == false
+    	piece.move_to!(params[:x_pos], params[:y_pos])
 		else
-			return render :edit, status: :unprocessable_entity
+			flash[:alert] = "Your move was obstructed!"
+			redirect_to game_path(piece.game)
 		end
+
 	end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -9,7 +9,7 @@ class PiecesController < ApplicationController
 		logger.info "Params:
 		Orig x_pos: #{piece.x_pos}, Orig y_pos: #{piece.y_pos},
 		Dest x_pos: #{params[:x_pos]}, Dest y_pos: #{params[:y_pos]}"
-		
+		logger.info "is_obstructed? result: #{piece.is_obstructed?(params[:x_pos], params[:y_pos]).to_s}"
 
 		@game = piece.game
 		

--- a/app/models/concerns/movements.rb
+++ b/app/models/concerns/movements.rb
@@ -1,23 +1,25 @@
 module Movements
+  destination_x = destination_x.to_i
+  destination_y = destination_y.to_i
 
   def starting_point_x
-    @starting_point_x = self.x_pos
+    @starting_point_x = self.x_pos.to_i
   end
 
   def starting_point_y
-    @starting_point_y = self.y_pos
+    @starting_point_y = self.y_pos.to_i
   end
 
   def right_or_left(destination_x)
-    return 1 if starting_point_x < destination_x.to_i
-    return -1 if starting_point_x > destination_x.to_i
-    return 0 if starting_point_x == destination_x.to_i
+    return 1 if starting_point_x < destination_x
+    return -1 if starting_point_x > destination_x
+    return 0 if starting_point_x == destination_x
   end
   
   def up_or_down(destination_y)
-    return 1 if starting_point_y < destination_y.to_i
-    return -1 if starting_point_y > destination_y.to_i
-    return 0 if starting_point_y == destination_y.to_i
+    return 1 if starting_point_y < destination_y
+    return -1 if starting_point_y > destination_y
+    return 0 if starting_point_y == destination_y
   end
 
 end

--- a/app/models/concerns/movements.rb
+++ b/app/models/concerns/movements.rb
@@ -1,13 +1,11 @@
 module Movements
-  destination_x = destination_x.to_i
-  destination_y = destination_y.to_i
-
+  
   def starting_point_x
-    @starting_point_x = self.x_pos.to_i
+    @starting_point_x = self.x_pos
   end
 
   def starting_point_y
-    @starting_point_y = self.y_pos.to_i
+    @starting_point_y = self.y_pos
   end
 
   def right_or_left(destination_x)

--- a/app/models/concerns/movements.rb
+++ b/app/models/concerns/movements.rb
@@ -9,15 +9,15 @@ module Movements
   end
 
   def right_or_left(destination_x)
-    return 1 if starting_point_x < destination_x
-    return -1 if starting_point_x > destination_x
-    return 0 if starting_point_x == destination_x
+    return 1 if self.starting_point_x < destination_x
+    return -1 if self.starting_point_x > destination_x
+    return 0 if self.starting_point_x == destination_x
   end
   
   def up_or_down(destination_y)
-    return 1 if starting_point_y < destination_y
-    return -1 if starting_point_y > destination_y
-    return 0 if starting_point_y == destination_y
+    return 1 if self.starting_point_y < destination_y
+    return -1 if self.starting_point_y > destination_y
+    return 0 if self.starting_point_y == destination_y
   end
 
 end

--- a/app/models/concerns/movements.rb
+++ b/app/models/concerns/movements.rb
@@ -9,15 +9,15 @@ module Movements
   end
 
   def right_or_left(destination_x)
-    return 1 if self.starting_point_x < destination_x
-    return -1 if self.starting_point_x > destination_x
-    return 0 if self.starting_point_x == destination_x
+    return 1 if starting_point_x < destination_x.to_i
+    return -1 if starting_point_x > destination_x.to_i
+    return 0 if starting_point_x == destination_x.to_i
   end
   
   def up_or_down(destination_y)
-    return 1 if self.starting_point_y < destination_y
-    return -1 if self.starting_point_y > destination_y
-    return 0 if self.starting_point_y == destination_y
+    return 1 if starting_point_y < destination_y.to_i
+    return -1 if starting_point_y > destination_y.to_i
+    return 0 if starting_point_y == destination_y.to_i
   end
 
 end

--- a/app/models/concerns/obstructions.rb
+++ b/app/models/concerns/obstructions.rb
@@ -5,8 +5,15 @@ module Obstructions
   # Check for obstructions
   def is_obstructed?(destination_x, destination_y)
     # Knights can't be obstructed
-    return "invalid" if self.name == "Knight"
+    return false if self.name == "Knight"
 
+    destination_x = destination_x.to_i
+    destination_y = destination_y.to_i
+
+    logger.info "is_obstructed called:
+    starting_point_x: #{starting_point_x.inspect}, starting_point_y: #{starting_point_y.inspect}
+    destination_x: #{destination_x.inspect}, destination_y: #{destination_y.inspect}"
+    
     if starting_point_y == destination_y                    # If y doesn't change, movement is horizontal
       horizontal_obstruction?(destination_x, destination_y)
     elsif starting_point_x == destination_x                 # If x doesn't change, movement is vertical
@@ -20,6 +27,7 @@ module Obstructions
 
   # Check for horizontal obstruction
   def horizontal_obstruction?(destination_x, y)
+    logger.info "horizontal_obstruction? called"
     move_x = starting_point_x + right_or_left(destination_x)
 
     while move_x != destination_x
@@ -32,6 +40,7 @@ module Obstructions
 
   # Check for vertical obstruction
   def vertical_obstruction?(x, destination_y)
+    logger.info "vertical_obstruction? called"
     move_y = starting_point_y + up_or_down(destination_y)
 
     while move_y != destination_y
@@ -44,6 +53,7 @@ module Obstructions
 
   # Check for diagonal obstruction
   def diagonal_obstruction?(destination_x, destination_y)
+    logger.info "diagonal_obstruction? called"
     move_x = starting_point_x + right_or_left(destination_x)
     move_y = starting_point_y + up_or_down(destination_y)
 

--- a/app/models/concerns/obstructions.rb
+++ b/app/models/concerns/obstructions.rb
@@ -22,7 +22,6 @@ module Obstructions
 
   # Check for horizontal obstruction
   def horizontal_obstruction?(destination_x, y)
-    logger.info "horizontal_obstruction? called"
     move_x = starting_point_x + right_or_left(destination_x)
 
     while move_x != destination_x
@@ -35,7 +34,6 @@ module Obstructions
 
   # Check for vertical obstruction
   def vertical_obstruction?(x, destination_y)
-    logger.info "vertical_obstruction? called"
     move_y = starting_point_y + up_or_down(destination_y)
 
     while move_y != destination_y
@@ -48,7 +46,6 @@ module Obstructions
 
   # Check for diagonal obstruction
   def diagonal_obstruction?(destination_x, destination_y)
-    logger.info "diagonal_obstruction? called"
     move_x = starting_point_x + right_or_left(destination_x)
     move_y = starting_point_y + up_or_down(destination_y)
 

--- a/app/models/concerns/obstructions.rb
+++ b/app/models/concerns/obstructions.rb
@@ -5,9 +5,6 @@ module Obstructions
     # Knights can't be obstructed
     return false if self.name == "Knight"
 
-    destination_x = destination_x.to_i
-    destination_y = destination_y.to_i
-
     logger.info "is_obstructed called:
     starting_point_x: #{starting_point_x.inspect}, starting_point_y: #{starting_point_y.inspect}
     destination_x: #{destination_x.inspect}, destination_y: #{destination_y.inspect}"

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -20,6 +20,6 @@ after_create :icon
   end
 
   def knight_move_tall?(to_x, to_y)
-    (starting_point_x - to_x).abs.to_i == 1 && (starting_point_y - to_y).abs.to_i == 2
+    (starting_point_x - to_x).abs == 1 && (starting_point_y - to_y).abs == 2
   end
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -9,7 +9,7 @@ after_create :icon
     end
   end
 
-  def valid_move?(to_x, to_y)
+  def valid_move?(to_x, to_y)    
     knight_move_wide?(to_x, to_y) || knight_move_tall?(to_x, to_y)
   end
 
@@ -20,6 +20,6 @@ after_create :icon
   end
 
   def knight_move_tall?(to_x, to_y)
-    (starting_point_x - to_x).abs == 1 && (starting_point_y - to_y).abs == 2
+    (starting_point_x - to_x).abs.to_i == 1 && (starting_point_y - to_y).abs.to_i == 2
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -18,22 +18,31 @@ class Piece < ApplicationRecord
 		%w(King Queen Bishop Knight Rook Pawn)
 	end
 
-  def find_piece(x, y, game_id)
+  def find_piece(x, y)
     Piece.find_by(x_pos: x, y_pos: y, game_id: game_id)
   end
 
-  def capture_piece!(x, y)
-    piece_to_capture = find_piece(x, y, self.game_id)
-
-    if piece_to_capture && piece_to_capture.color != self.color
-      piece_to_capture.update_attributes(x_pos: nil, y_pos: nil, captured: true)
-    end
+  def friendly_piece?(other_piece)
+    other_piece.color == self.color
   end
 
-  def move_to!(destination_x, destination_y)
-    capture_piece!(destination_x, destination_y)
+  def opposite_piece?(other_piece)
+    !friendly_piece?(other_piece)
+  end
 
-    self.update_attributes(x_pos: destination_x, y_pos: destination_y)
+  def capture_piece!(x, y, piece_to_capture)
+    piece_to_capture.update_attributes(x_pos: nil, y_pos: nil, captured: true)
+    self.update_attributes(x_pos: x, y_pos: y)
+  end
+
+  def move_to!(to_x, to_y)
+    piece_on_square = find_piece(to_x, to_y)
+
+    if piece_on_square && opposite_piece?(piece_on_square)
+      capture_piece!(to_x, to_y, piece_on_square)
+    elsif !piece_on_square
+      self.update_attributes(x_pos: to_x, y_pos: to_y)
+    end
   end
 
 end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe PiecesController, type: :controller do
   describe 'pieces#update action' do
   	it 'should update the position of the piece to a new position' do
   		patch :update, params: { game_id: game.id, id: piece.id, x_pos: 7, y_pos: 3 }
-  		# expect(response).to redirect_to game_path(game)
   		piece.reload
   		expect(piece.x_pos).to eq 7
   		expect(piece.y_pos).to eq 3

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe PiecesController, type: :controller do
   let!(:user) { FactoryGirl.create(:user) }
   let!(:game) { FactoryGirl.create(:game, white_player_id: user.id) }
-  let!(:piece) { FactoryGirl.create(:piece, game_id: game.id, color: 'black', name: "Rook", x_pos: 7, y_pos: 5) }
+  let(:piece) { FactoryGirl.create(:piece, game_id: game.id, color: 'Black', name: "Rook", x_pos: 7, y_pos: 5) }
 
   describe 'pieces#show action' do
     it 'should successfully show the page of the game' do
   		get :show, params: { game_id: game.id, id: piece.id }
   		expect(response).to have_http_status(:success)
-  		expect(piece.color).to eq('black')
+  		expect(piece.color).to eq('Black')
     end
   end
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PiecesController, type: :controller do
   let!(:user) { FactoryGirl.create(:user) }
   let!(:game) { FactoryGirl.create(:game, white_player_id: user.id) }
-  let!(:piece) { FactoryGirl.create(:piece, game_id: game.id, color: 'black') }
+  let!(:piece) { FactoryGirl.create(:piece, game_id: game.id, color: 'black', name: "Rook", x_pos: 7, y_pos: 5) }
 
   describe 'pieces#show action' do
     it 'should successfully show the page of the game' do
@@ -15,11 +15,11 @@ RSpec.describe PiecesController, type: :controller do
 
   describe 'pieces#update action' do
   	it 'should update the position of the piece to a new position' do
-  		patch :update, params: { game_id: game.id, id: piece.id, x_pos: 7, y_pos: 6 }
+  		patch :update, params: { game_id: game.id, id: piece.id, x_pos: 7, y_pos: 3 }
   		# expect(response).to redirect_to game_path(game)
   		piece.reload
   		expect(piece.x_pos).to eq 7
-  		expect(piece.y_pos).to eq 6
+  		expect(piece.y_pos).to eq 3
   	end
 
   	it 'should render 404 if the piece cannot be found' do

--- a/spec/models/concerns/obstructions_spec.rb
+++ b/spec/models/concerns/obstructions_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Piece, type: :model do
       let(:destination_x) { 5 }
       let(:destination_y) { 3 }
 
-      it { is_expected.to eq("invalid") }
+      it { is_expected.to eq(false) }
     end
 
     describe 'Any obstructions' do      

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -7,41 +7,21 @@ RSpec.describe Piece, type: :model do
 
   describe "#capture_piece!" do
     let(:piece_capturer) { FactoryGirl.create(:bishop, color: "Black", x_pos: 7, y_pos: 3, game_id: game.id) }
-    let(:piece_target) { FactoryGirl.create(:pawn, color: captured_color, x_pos: target_x, y_pos: target_y, game_id: game.id) }
+    let(:piece_target) { FactoryGirl.create(:pawn, color: "White", x_pos: target_x, y_pos: target_y, game_id: game.id) }
     let(:target_x) { 5 }
     let(:target_y) { 5 }
     
-    context 'capture opposing piece' do
-      let(:captured_color) { "White" }
+    it ', remove opposing piece from board and update piece position' do
+      expect(piece_target.x_pos).to eq(target_x)
+      expect(piece_target.y_pos).to eq(target_y)
 
-      it ', remove opposing piece from board, and update piece position' do
-        expect(piece_target.x_pos).to eq(target_x)
-        expect(piece_target.y_pos).to eq(target_y)
+      piece_capturer.capture_piece!(target_x, target_y, piece_target)
+      piece_target.reload
 
-        piece_capturer.capture_piece!(target_x, target_y)
-        piece_target.reload
-
-        expect(piece_target.x_pos).to eq(nil)
-        expect(piece_target.y_pos).to eq(nil)
-        expect(piece_target.captured).to eq(true)
-      end
-    end
-
-    context 'cannot capture your own piece' do
-      let(:captured_color) { "Black" }
-
-      it ', target piece doesn\'t change' do
-        expect(piece_target.x_pos).to eq(target_x)
-        expect(piece_target.y_pos).to eq(target_y)
-
-        piece_capturer.capture_piece!(target_x, target_y)
-        piece_target.reload
-
-        expect(piece_target.x_pos).to eq(target_x)
-        expect(piece_target.y_pos).to eq(target_y)
-        expect(piece_target.captured).to eq(false)
-      end
-    end     
+      expect(piece_target.x_pos).to eq(nil)
+      expect(piece_target.y_pos).to eq(nil)
+      expect(piece_target.captured).to eq(true)
+    end  
   end    
 
   describe "#move_to!" do
@@ -58,22 +38,44 @@ RSpec.describe Piece, type: :model do
     end
 
     context 'move and capture' do
-      let(:captured_piece) { FactoryGirl.create(:knight, color: "White", x_pos: 6, y_pos: 6, game_id: game.id) }
+      let(:other_piece) { FactoryGirl.create(:knight, color: other_color, x_pos: destination_x, y_pos: destination_y, game_id: game.id) }
 
-      it ', update positions of moving piece and captured piece' do
-        expect(captured_piece.x_pos).to eq(6)
-        expect(captured_piece.y_pos).to eq(6)
+      context 'capture opponent\'s piece' do
+        let(:other_color) { "White" }
 
-        piece_moving.move_to!(destination_x, destination_y)
-        captured_piece.reload
+        it ', update positions of moving piece and captured piece' do
+          expect(other_piece.x_pos).to eq(destination_x)
+          expect(other_piece.y_pos).to eq(destination_x)
 
-        expect(captured_piece.x_pos).to eq(nil)
-        expect(captured_piece.y_pos).to eq(nil)
-        expect(captured_piece.captured).to eq(true)
-        expect(piece_moving.x_pos).to eq(destination_x)
-        expect(piece_moving.y_pos).to eq(destination_y)
+          piece_moving.move_to!(destination_x, destination_y)
+          other_piece.reload
+
+          expect(other_piece.x_pos).to eq(nil)
+          expect(other_piece.y_pos).to eq(nil)
+          expect(other_piece.captured).to eq(true)
+          expect(piece_moving.x_pos).to eq(destination_x)
+          expect(piece_moving.y_pos).to eq(destination_y)
+        end
       end
-    end
+
+      context 'cannot move or capture if your own piece is there' do
+        let(:other_color) { "Black" }
+
+        it ', piece positions do not change' do
+          expect(other_piece.x_pos).to eq(destination_x)
+          expect(other_piece.y_pos).to eq(destination_x)
+
+          piece_moving.move_to!(destination_x, destination_x)
+          other_piece.reload
+
+          expect(other_piece.x_pos).to eq(destination_x)
+          expect(other_piece.y_pos).to eq(destination_x)
+          expect(other_piece.captured).to eq(false)
+          expect(piece_moving.x_pos).to eq(7)
+          expect(piece_moving.y_pos).to eq(7)
+        end
+      end
+    end      
   end
   
 end


### PR DESCRIPTION
- Can now move and capture pieces with integrated `move_to!` method in the pieces_controller
- Integrated `valid_move?` logic with the piece controllers #update action
- Display flash message when a move is obstructed or invalid.
- Converted `x_pos` and `y_pos` parameters to `FixNum` with `.to_i` in piece_controller to avoid `TypeError` comparison.
- Changed `is_obstructed?` for `knight` from `"invalid"` to `false` for consistency.

Updated 2 tests.
- In **pieces_controller.spec**: Provided starting FactoryGirl `piece` with `x_pos` and `y_pos` params for #update action  to avoid `patch` comparison with `nil` type.
- In **obstructions_spec.rb**: Updated `is_expected.to eq(false)` for `knight`

(Nikhil: updated methods and tests for `move_to!` and `capture_piece!`, so that a piece can't move to a square occupied by one of its own.)