### PR TITLE
Refactor & consolidate common piece move logic

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -11,13 +11,7 @@ class Bishop < Piece
 
   def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
-    bishop_move_diagonal?(to_x, to_y)
+    diagonal_move?(to_x, to_y)
   end
-
-  private
-
-  def bishop_move_diagonal?(to_x, to_y)
-    (starting_point_x - to_x).abs == (starting_point_y - to_y).abs
-  end  
 
 end

--- a/app/models/concerns/movements.rb
+++ b/app/models/concerns/movements.rb
@@ -20,12 +20,20 @@ module Movements
     return 0 if starting_point_y == destination_y
   end
 
-  def horizontal_move?(to_x, to_y)
-    to_x != starting_point_x && starting_point_y == to_y
+  def horizontal_move?(to_x)
+    right_or_left(to_x) != 0
   end
 
-  def vertical_move?(to_y, to_x)
-    to_y != starting_point_y && starting_point_x == to_x
+  def vertical_move?(to_y)
+    up_or_down(to_y) != 0
+  end
+
+  def only_horizontal_move?(to_x, to_y)
+    horizontal_move?(to_x) && !vertical_move?(to_y)
+  end
+
+  def only_vertical_move?(to_x, to_y)
+    vertical_move?(to_y) && !horizontal_move?(to_x)
   end
 
   def diagonal_move?(to_x, to_y)

--- a/app/models/concerns/movements.rb
+++ b/app/models/concerns/movements.rb
@@ -24,20 +24,32 @@ module Movements
     right_or_left(to_x) != 0
   end
 
+  def horizontal_move_only?(to_x, to_y)
+    horizontal_move?(to_x) && !vertical_move?(to_y)
+  end
+
+  def horizontal_move_one_square?(to_x)
+    horizontal_move?(to_x) && to_x == starting_point_x + right_or_left(to_x)
+  end
+
   def vertical_move?(to_y)
     up_or_down(to_y) != 0
   end
 
-  def only_horizontal_move?(to_x, to_y)
-    horizontal_move?(to_x) && !vertical_move?(to_y)
+  def vertical_move_only?(to_x, to_y)
+    vertical_move?(to_y) && !horizontal_move?(to_x)
   end
 
-  def only_vertical_move?(to_x, to_y)
-    vertical_move?(to_y) && !horizontal_move?(to_x)
+  def vertical_move_one_square?(to_y)
+    vertical_move?(to_y) && to_y == starting_point_y + up_or_down(to_y)
   end
 
   def diagonal_move?(to_x, to_y)
     (starting_point_x - to_x).abs == (starting_point_y - to_y).abs
-  end    
+  end
+
+  def diagonal_move_one_square?(to_x, to_y)
+    horizontal_move_one_square?(to_x) && vertical_move_one_square?(to_y)
+  end
 
 end

--- a/app/models/concerns/movements.rb
+++ b/app/models/concerns/movements.rb
@@ -28,4 +28,8 @@ module Movements
     to_y != starting_point_y && starting_point_x == to_x
   end
 
+  def diagonal_move?(to_x, to_y)
+    (starting_point_x - to_x).abs == (starting_point_y - to_y).abs
+  end    
+
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -10,21 +10,7 @@ after_create :icon
   end
 
   def valid_move?(to_x, to_y)
-    king_move_horizontal?(to_x) || king_move_vertical?(to_y) || king_move_diagonal?(to_x, to_y)
+    horizontal_move_one_square?(to_x) || vertical_move_one_square?(to_y) || diagonal_move_one_square?(to_x, to_y)
   end
-
-  private
-
-  def king_move_horizontal?(to_x)
-    right_or_left(to_x) != 0 && to_x == starting_point_x + right_or_left(to_x)
-  end
-
-  def king_move_vertical?(to_y)
-    up_or_down(to_y) != 0 && to_y == starting_point_y + up_or_down(to_y)
-  end
-
-  def king_move_diagonal?(to_x, to_y)
-    king_move_horizontal?(to_x) && king_move_vertical?(to_y)
-  end  
 
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -22,4 +22,5 @@ after_create :icon
   def knight_move_tall?(to_x, to_y)
     (starting_point_x - to_x).abs == 1 && (starting_point_y - to_y).abs == 2
   end
+  
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -19,7 +19,8 @@ class Piece < ApplicationRecord
 	end
 
   def find_piece(x, y)
-    Piece.find_by(x_pos: x, y_pos: y, game_id: game_id)
+    # Piece.find_by(x_pos: x, y_pos: y, game_id: game_id)
+    game.pieces.find_by(x_pos: x, y_pos: y)
   end
 
   def friendly_piece?(other_piece)

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -13,7 +13,7 @@ after_create :icon
     return false if self.is_obstructed?(to_x, to_y)
 
     if queen_move_horizontal?(to_x) && queen_move_vertical?(to_y)
-      queen_move_diagonal?(to_x, to_y)
+      diagonal_move?(to_x, to_y)
     else
       queen_move_horizontal?(to_x) || queen_move_vertical?(to_y)
     end
@@ -28,9 +28,5 @@ after_create :icon
   def queen_move_vertical?(to_y)
     up_or_down(to_y) != 0
   end
-
-  def queen_move_diagonal?(to_x, to_y)
-    (starting_point_x - to_x).abs == (starting_point_y - to_y).abs
-  end  
 
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -11,7 +11,7 @@ after_create :icon
 
   def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
-    only_horizontal_move?(to_x, to_y) || only_vertical_move?(to_x, to_y) || diagonal_move?(to_x, to_y)
+    horizontal_move_only?(to_x, to_y) || vertical_move_only?(to_x, to_y) || diagonal_move?(to_x, to_y)
   end
 
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -11,22 +11,7 @@ after_create :icon
 
   def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
-
-    if queen_move_horizontal?(to_x) && queen_move_vertical?(to_y)
-      diagonal_move?(to_x, to_y)
-    else
-      queen_move_horizontal?(to_x) || queen_move_vertical?(to_y)
-    end
-  end
-
-  private
-
-  def queen_move_horizontal?(to_x)
-    right_or_left(to_x) != 0
-  end
-
-  def queen_move_vertical?(to_y)
-    up_or_down(to_y) != 0
+    only_horizontal_move?(to_x, to_y) || only_vertical_move?(to_x, to_y) || diagonal_move?(to_x, to_y)
   end
 
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -11,6 +11,7 @@ after_create :icon
 
   def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
-    horizontal_move?(to_x, to_y) || vertical_move?(to_y, to_x)
+    only_horizontal_move?(to_x, to_y) || only_vertical_move?(to_x, to_y)
   end
+  
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -11,7 +11,7 @@ after_create :icon
 
   def valid_move?(to_x, to_y)
     return false if self.is_obstructed?(to_x, to_y)
-    only_horizontal_move?(to_x, to_y) || only_vertical_move?(to_x, to_y)
+    horizontal_move_only?(to_x, to_y) || vertical_move_only?(to_x, to_y)
   end
   
 end


### PR DESCRIPTION
- Since many of the pieces share common move logic, I've consolidated these moves and put them into models/concerns/movements.rb.  This way multiple pieces can use the same code where needed.

- This simplifies the code for most of the piece `valid_move?` methods, and removes most of their private methods.  The *Knight* hasn't changed, since it's moves are unique.

- The *Pawn* has a mix of common and unique moves, so these new common moves should come in handy for the Pawn `valid_move?` method.

- I updated the `find_piece` method to only query "this" game's pieces (rather than the entire database).

- All tests are passing, and front-end gameplay is unchanged (pieces can move/capture/etc as before).