### PR TITLE
Restore create_games migration

### DIFF
--- a/db/migrate/20170515193637_create_games.rb
+++ b/db/migrate/20170515193637_create_games.rb
@@ -1,0 +1,8 @@
+class CreateGames < ActiveRecord::Migration[5.0]
+  def change
+    create_table :games do |t|
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This restores the create_games migration file, which had been deleted by mistake in a previous PR merge.